### PR TITLE
[ti-6.2] ver3.6対応（custom→settingへの移動）

### DIFF
--- a/js/danoni_custom.js
+++ b/js/danoni_custom.js
@@ -55,16 +55,7 @@ function customLoadingProgress(_event) {
 function customTitleInit() {
 
 	// バージョン表記
-	g_localVersion = `ti-6.1`;
-
-	// デフォルトの曲名表示を利用しない場合は、下記をコメント化してください。
-	// もう一方のcustomファイルを使って再上書きも可能です。
-
-	g_headerObj.customTitleUse = `false`;
-	g_headerObj.customTitleArrowUse = `false`;
-	g_headerObj.customBackUse = `false`;
-	g_headerObj.customBackMainUse = `false`;
-	g_headerObj.customReadyUse = `false`;
+	g_localVersion = `ti-6.2`;
 
 	// 製作者のデフォルトアドレス
 	if (g_headerObj.creatorUrl === location.href) {

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -16,10 +16,10 @@ const g_presetTuningUrl = `http://cw7.sakura.ne.jp/`;
 
 // ゲージ設定（デフォルト）
 const g_presetGauge = {
-	Border: 70,  // ノルマ制でのボーダーライン、ライフ制にしたい場合は `x` を指定
-	Recovery: 2, // 回復量
-	Damage: 7,   // ダメージ量
-	Init: 25,    // 初期値
+	//	Border: 70,  // ノルマ制でのボーダーライン、ライフ制にしたい場合は `x` を指定
+	//	Recovery: 2, // 回復量
+	//	Damage: 7,   // ダメージ量
+	//	Init: 25,    // 初期値
 };
 
 // ゲージ設定（デフォルト以外）
@@ -37,6 +37,16 @@ const g_presetGaugeCustom = {
 		Init: 100,
 	},
 };
+
+// デフォルトのデザインを使用せず、独自のデザインを使用するかを指定
+// カスタムデザインにする場合は `true` を指定
+const g_presetCustomDesignUse = {
+	title: `false`,
+	titleArrow: `false`,
+	back: `false`,
+	backMain: `false`,
+	ready: `false`,
+}
 
 // オプション利用設定（デフォルト）
 // 一律使用させたくない場合は `false` を指定（デフォルトは `true`）


### PR DESCRIPTION
## 変更内容
- danoni_custom.js で定義している箇所を danoni_setting.js へ移動。

## 変更理由
- ver3.6より、デフォルトデザインの指定が任意となったため。
- 譜面ヘッダーによる設定を容易にするため。