### PR TITLE
[setting:0.2.0] 7keyに対してCross/Splitなどの設定を可能に変更

### DIFF
--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -57,6 +57,78 @@ const g_presetSettingUse = {
 	gauge: `true`
 };
 
+g_presetFrzStartjdgUse = `false`;
+
+// 7key用のキーコン設定
+// 1: Cross, 2: Split, 3: Alternate, 4:Twist, 5:Asymmetry
+// transKeyを定義しているため、演出によりこれらを使わせたくない作品には |transKeyUse=false| を使用する。
+g_keyObj.chara7_1 = [`left`, `leftdia`, `rightdia`, `right`, `down`, `space`, `up`];
+g_keyObj.chara7_2 = [`left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`];
+g_keyObj.chara7_3 = [`left`, `down`, `up`, `right`, `leftdia`, `space`, `rightdia`];
+g_keyObj.chara7_4 = [`left`, `leftdia`, `up`, `rightdia`, `down`, `space`, `right`];
+g_keyObj.chara7_5 = [`left`, `down`, `rightdia`, `leftdia`, `space`, `up`, `right`];
+
+g_keyObj.color7_1 = [0, 1, 1, 0, 0, 2, 0];
+g_keyObj.color7_2 = [0, 1, 0, 2, 0, 1, 0];
+g_keyObj.color7_3 = [0, 0, 0, 0, 1, 2, 1];
+g_keyObj.color7_4 = [0, 1, 0, 1, 0, 2, 0];
+g_keyObj.color7_5 = [0, 0, 1, 1, 2, 0, 0];
+
+g_keyObj.shuffle7_1 = [0, 0, 0, 0, 0, 1, 0];
+g_keyObj.shuffle7_2 = [0, 0, 0, 1, 0, 0, 0];
+g_keyObj.shuffle7_3 = [0, 0, 0, 0, 0, 1, 0];
+g_keyObj.shuffle7_4 = [0, 0, 0, 0, 0, 1, 0];
+g_keyObj.shuffle7_5 = [0, 0, 0, 0, 0, 1, 0];
+
+g_keyObj.stepRtn7_1 = [0, -45, 135, 180, -90, `onigiri`, 90];
+g_keyObj.stepRtn7_2 = [0, -45, -90, `onigiri`, 90, 135, 180];
+g_keyObj.stepRtn7_3 = [0, -90, 90, 180, -45, `onigiri`, 135];
+g_keyObj.stepRtn7_4 = [0, -45, 90, 135, -90, `onigiri`, 180];
+g_keyObj.stepRtn7_5 = [0, -90, 135, -45, `onigiri`, 90, 180];
+
+g_keyObj.div7_1 = 7;
+g_keyObj.div7_2 = 7;
+g_keyObj.div7_3 = 7;
+g_keyObj.div7_4 = 7;
+g_keyObj.div7_5 = 7;
+
+g_keyObj.pos7_1 = [0, 1, 5, 6, 7, 8, 9];
+g_keyObj.pos7_2 = [0, 1, 2, 10, 11, 12, 13];
+g_keyObj.pos7_3 = [0, 2, 4, 6, 7, 9, 11];
+g_keyObj.pos7_4 = [0, 1, 4, 5, 9, 10, 13];
+g_keyObj.pos7_5 = [0, 2, 5, 8, 10, 11, 13];
+
+g_keyObj.keyCtrl7_1 = [[83], [68, 0], [75, 0], [76], [70], [32, 0], [74]];
+g_keyObj.keyCtrl7_2 = [[83], [68, 0], [70], [32, 0], [74], [75, 0], [76]];
+g_keyObj.keyCtrl7_3 = [[83], [70], [74], [76], [68, 0], [32, 0], [75, 0]];
+g_keyObj.keyCtrl7_4 = [[83], [68, 0], [74], [75, 0], [70], [32, 0], [76]];
+g_keyObj.keyCtrl7_5 = [[83], [70], [75, 0], [68, 0], [32, 0], [74], [76]];
+
+g_keyObj.keyCtrl7_1d = [[83], [68, 0], [75, 0], [76], [70], [32, 0], [74]];
+g_keyObj.keyCtrl7_2d = [[83], [68, 0], [70], [32, 0], [74], [75, 0], [76]];
+g_keyObj.keyCtrl7_3d = [[83], [70], [74], [76], [68, 0], [32, 0], [75, 0]];
+g_keyObj.keyCtrl7_4d = [[83], [68, 0], [74], [75, 0], [70], [32, 0], [76]];
+g_keyObj.keyCtrl7_5d = [[83], [70], [75, 0], [68, 0], [32, 0], [74], [76]];
+
+g_keyObj.transKey7_1 = `Cross`;
+g_keyObj.transKey7_2 = `Split`;
+g_keyObj.transKey7_3 = `Alternate`;
+g_keyObj.transKey7_4 = `Twist`;
+g_keyObj.transKey7_5 = `Asymmetry`;
+
+// 作品個別に定義する場合は下記と同じ
+/*
+|keyExtraList=7|
+|color7=$0,1,1,0,0,2,0$0,1,0,2,0,1,0$0,0,0,0,1,2,1$0,1,0,1,0,2,0$0,0,1,1,2,0,0|
+|chara7=$left,leftdia,rightdia,right,down,space,up$left,leftdia,down,space,up,rightdia,right$left,down,up,right,leftdia,space,rightdia$left,leftdia,up,rightdia,down,space,right$left,down,rightdia,leftdia,space,up,right|
+|div7=$7$7$7$7$7|
+|blank7=55$55$55$55$55$55|
+|pos7=$0,1,5,6,7,8,9$0,1,2,10,11,12,13$0,2,4,6,7,9,11$0,1,4,5,9,10,13$0,2,5,8,10,11,13|
+|stepRtn7=$0,-45,135,180,-90,onigiri,90$0,-45,-90,onigiri,90,135,180$0,-90,90,180,-45,onigiri,135$0,-45,90,135,-90,onigiri,180$0,-90,135,-45,onigiri,90,180|
+|keyCtrl7=$83,68/0,75/0,76,70,32/0,74$83,68/0,70,32/0,74,75/0,76$83,70,74,76,68/0,32/0,75/0$83,68/0,74,75/0,70,32/0,76$83,70,75/0,68/0,32/0,74,76|
+|transKey7=$Cross$Split$Alternate$Twist$Asymmetry|
+*/
+
 // シャッフルグループの個別変更
 // 個別に上書きする場合は個々の danoni_custom2.js 内で実施
 // g_keyObj.shuffle11_0 = [0, 0, 0, 0, 1, 1, 1, 2, 3, 3, 3];


### PR DESCRIPTION
## 変更内容
- 7keyに対してCross/Splitなどの設定を可能に変更

## 補足
- 実験的に実装。別キー扱いとして追加している。
譜面ヘッダー `|transKeyUse=false|`を使用することで、使えないようにすることもできる。