### PR TITLE
[0166, 0190, 0216, 0316, settings] ver10.2.1対応

### DIFF
--- a/js/danoni_custom-0166.js
+++ b/js/danoni_custom-0166.js
@@ -17,15 +17,15 @@
  * 　画面遷移したときにきれいに消してくれます。
  */
 
-let g_tmpCnt1 = 0;
-let g_tmpCnt2 = 0;
+var g_tmpCnt1 = 0;
+var g_tmpCnt2 = 0;
 
 /**
  * タイトル画面 [Scene: Title / Melon]
  */
 function customTitleInit2() {
     // バージョン表記
-    g_localVersion2 = `sp-1`;
+    g_localVersion2 = `sp-2`;
 }
 
 
@@ -79,14 +79,17 @@ function customMainInit2() {
         for (var j = 0; j < keyNum; j++) {
 
             const step = document.querySelector(`#step${j}`);
+            const stepDiv = document.querySelector(`#stepDiv${j}`);
             const stepHit = document.querySelector(`#stepHit${j}`);
 
             if (g_keyObj[`color${keyCtrlPtn}`][j] <= 2) {
                 // 7keyを隠す
                 step.style.display = `none`;
+                stepDiv.style.opacity = 0;
                 stepHit.style.display = `none`;
-            } else if (g_stateObj.d_stepzone != C_FLG_OFF) {
+            } else if (g_stateObj.d_stepzone !== C_FLG_OFF && g_stateObj.scroll !== `Flat`) {
                 step.style.display = `inherit`;
+                stepDiv.style.opacity = 1;
                 stepHit.style.display = `inherit`;
             }
         }
@@ -96,14 +99,17 @@ function customMainInit2() {
         for (var j = 0; j < keyNum; j++) {
 
             const step = document.querySelector(`#step${j}`);
+            const stepDiv = document.querySelector(`#stepDiv${j}`);
             const stepHit = document.querySelector(`#stepHit${j}`);
 
             if (g_keyObj[`color${keyCtrlPtn}`][j] >= 3) {
                 // 5keyを隠す
                 step.style.display = `none`;
+                stepDiv.style.opacity = 0;
                 stepHit.style.display = `none`;
-            } else if (g_stateObj.d_stepzone != C_FLG_OFF) {
+            } else if (g_stateObj.d_stepzone !== C_FLG_OFF && g_stateObj.scroll !== `Flat`) {
                 step.style.display = `inherit`;
+                stepDiv.style.opacity = 1;
                 stepHit.style.display = `inherit`;
             }
         }
@@ -113,14 +119,17 @@ function customMainInit2() {
         for (var j = 0; j < keyNum; j++) {
 
             const step = document.querySelector(`#step${j}`);
+            const stepDiv = document.querySelector(`#stepDiv${j}`);
             const stepHit = document.querySelector(`#stepHit${j}`);
 
             if (g_keyObj[`color${keyCtrlPtn}`][j] <= 2) {
                 // 7keyを隠す
                 step.style.display = `none`;
+                stepDiv.style.opacity = 0;
                 stepHit.style.display = `none`;
-            } else if (g_stateObj.d_stepzone != C_FLG_OFF) {
+            } else if (g_stateObj.d_stepzone !== C_FLG_OFF && g_stateObj.scroll !== `Flat`) {
                 step.style.display = `inherit`;
+                stepDiv.style.opacity = 1;
                 stepHit.style.display = `inherit`;
             }
         }
@@ -130,13 +139,16 @@ function customMainInit2() {
         for (var j = 0; j < keyNum; j++) {
 
             const step = document.querySelector(`#step${j}`);
+            const stepDiv = document.querySelector(`#stepDiv${j}`);
             const stepHit = document.querySelector(`#stepHit${j}`);
 
             if (j <= 4 || j >= 8) {
                 step.style.display = `none`;
+                stepDiv.style.opacity = 0;
                 stepHit.style.display = `none`;
-            } else if (g_stateObj.d_stepzone != C_FLG_OFF) {
+            } else if (g_stateObj.d_stepzone !== C_FLG_OFF && g_stateObj.scroll !== `Flat`) {
                 step.style.display = `inherit`;
+                stepDiv.style.display = `inherit`;
                 stepHit.style.display = `inherit`;
             }
         }
@@ -145,13 +157,16 @@ function customMainInit2() {
         for (var j = 0; j < keyNum; j++) {
 
             const step = document.querySelector(`#step${j}`);
+            const stepDiv = document.querySelector(`#stepDiv${j}`);
             const stepHit = document.querySelector(`#stepHit${j}`);
 
             if (g_keyObj[`color${keyCtrlPtn}`][j] === 3) {
                 step.style.display = `none`;
+                stepDiv.style.opacity = 0;
                 stepHit.style.display = `none`;
-            } else if (g_stateObj.d_stepzone != C_FLG_OFF) {
+            } else if (g_stateObj.d_stepzone !== C_FLG_OFF && g_stateObj.scroll !== `Flat`) {
                 step.style.display = `inherit`;
+                stepDiv.style.opacity = 1;
                 stepHit.style.display = `inherit`;
             }
         }
@@ -160,13 +175,16 @@ function customMainInit2() {
         for (var j = 0; j < keyNum; j++) {
 
             const step = document.querySelector(`#step${j}`);
+            const stepDiv = document.querySelector(`#stepDiv${j}`);
             const stepHit = document.querySelector(`#stepHit${j}`);
 
             if (g_keyObj[`color${keyCtrlPtn}`][j] <= 2) {
                 step.style.display = `none`;
+                stepDiv.style.opacity = 0;
                 stepHit.style.display = `none`;
-            } else if (g_stateObj.d_stepzone != C_FLG_OFF) {
+            } else if (g_stateObj.d_stepzone !== C_FLG_OFF && g_stateObj.scroll !== `Flat`) {
                 step.style.display = `inherit`;
+                stepDiv.style.opacity = 1;
                 stepHit.style.display = `inherit`;
             }
         }
@@ -176,10 +194,12 @@ function customMainInit2() {
         for (var j = 0; j < keyNum; j++) {
 
             const step = document.querySelector(`#step${j}`);
+            const stepDiv = document.querySelector(`#stepDiv${j}`);
             const stepHit = document.querySelector(`#stepHit${j}`);
 
             if (g_keyObj[`color${keyCtrlPtn}`][j] === 4) {
                 step.style.display = `none`;
+                stepDiv.style.opacity = 0;
                 stepHit.style.display = `none`;
             }
         }
@@ -279,6 +299,8 @@ function customMainEnterFrame2() {
         for (var j = 0; j < keyNum; j++) {
             if (j >= 5 && j <= 7) {
                 displayDefaultStep(j);
+            } else if (g_keyObj[`color${keyCtrlPtn}`][j] === 4) {
+                displayOutStep(j);
             }
         }
 
@@ -347,9 +369,11 @@ function fadeOutStep(_pos) {
 
 function displayOutStep(_pos) {
     const step = document.querySelector(`#step${_pos}`);
+    const stepDiv = document.querySelector(`#stepDiv${_pos}`);
     const stepHit = document.querySelector(`#stepHit${_pos}`);
     step.style.opacity = 1;
     step.style.display = "none";
+    stepDiv.style.opacity = 0;
     stepHit.style.display = "none";
 }
 
@@ -361,12 +385,14 @@ function fadeInStep(_pos) {
 
 function displayInStep(_pos) {
     const step = document.querySelector(`#step${_pos}`);
+    const stepDiv = document.querySelector(`#stepDiv${_pos}`);
     const stepHit = document.querySelector(`#stepHit${_pos}`);
     step.style.opacity = 0;
-    if (g_stateObj.d_stepzone != C_FLG_OFF) {
+    if (g_stateObj.d_stepzone !== C_FLG_OFF && g_stateObj.scroll !== `Flat`) {
         step.style.display = "inherit";
-        stepHit.style.display = "inherit";
     }
+    stepDiv.style.opacity = 1;
+    stepHit.style.display = "inherit";
 }
 
 function displayDefaultStep(_pos) {

--- a/js/danoni_custom-0190.js
+++ b/js/danoni_custom-0190.js
@@ -25,7 +25,7 @@ var g_tmpCnt2 = 0;
  */
 function customTitleInit2() {
 	// バージョン表記
-	g_localVersion2 = "sp-1";
+	g_localVersion2 = "sp-3";
 }
 
 
@@ -83,7 +83,7 @@ function customMainInit2() {
 		// 一部の矢印を非表示化することで表現が可能。
 		for (var j = 0; j < keyNum; j++) {
 			if (g_keyObj["color" + keyCtrlPtn][j] == 4) {
-				var step = document.getElementById("step" + j);
+				var step = document.getElementById("stepRoot" + j);
 				g_workObj.stepX[j] -= 55;
 				step.style.left = g_workObj.stepX[j] + "px";
 				if (actualFrame >= 7520 && actualFrame < 12879) {
@@ -91,13 +91,16 @@ function customMainInit2() {
 				}
 
 				var stepHit = document.getElementById("stepHit" + j);
-				stepHit.style.left = parseFloat(g_workObj.stepX[j] - 15) + "px";
+				//stepHit.style.left = parseFloat(g_workObj.stepX[j] - 15) + "px";
 				if (actualFrame >= 7520 && actualFrame < 12879) {
 					stepHit.style.display = "none";
 				}
 
-			} else if (g_keyObj["color" + keyCtrlPtn][j] == 3) {
-				var step = document.getElementById("step" + j);
+				var frzHit = document.getElementById("frzHit" + j);
+				frzHit.style.left = g_workObj.stepX[j] + "px";
+
+			} else if (g_keyObj["color" + keyCtrlPtn][j] === 3) {
+				var step = document.getElementById("stepRoot" + j);
 				g_workObj.stepX[j] += 55;
 				step.style.left = g_workObj.stepX[j] + "px";
 				if (actualFrame < 7519) {
@@ -105,12 +108,16 @@ function customMainInit2() {
 				}
 
 				var stepHit = document.getElementById("stepHit" + j);
-				stepHit.style.left = parseFloat(g_workObj.stepX[j] - 15) + "px";
+				//stepHit.style.left = parseFloat(g_workObj.stepX[j] - 15) + "px";
 				if (actualFrame < 7519) {
 					stepHit.style.display = "none";
 				}
+
+				var frzHit = document.getElementById("frzHit" + j);
+				frzHit.style.left = g_workObj.stepX[j] + "px";
+
 			} else if (g_keyObj["color" + keyCtrlPtn][j] <= 2) {
-				var step = document.getElementById("step" + j);
+				var step = document.getElementById("stepRoot" + j);
 				step.style.opacity = 1;
 			}
 
@@ -136,21 +143,24 @@ function customMainInit2() {
 			if (g_keyObj["color" + keyCtrlPtn][j] == 3) {
 				g_workObj.stepX[j] -= 27.5 * 1;
 
-				var step = document.getElementById("step" + j);
+				var step = document.getElementById("stepRoot" + j);
 				step.style.left = g_workObj.stepX[j] + "px";
 				var stepHit = document.getElementById("stepHit" + j);
-				stepHit.style.left = (g_workObj.stepX[j] - 15) + "px";
+				//stepHit.style.left = (g_workObj.stepX[j] - 15) + "px";
 				stepHit.style.display = "inherit";
-
+				var frzHit = document.getElementById("frzHit" + j);
+				frzHit.style.left = g_workObj.stepX[j] + "px";
 
 			} else if (g_keyObj["color" + keyCtrlPtn][j] == 4) {
 				g_workObj.stepX[j] += 27.5 * 1;
 
-				var step = document.getElementById("step" + j);
+				var step = document.getElementById("stepRoot" + j);
 				step.style.left = g_workObj.stepX[j] + "px";
 				var stepHit = document.getElementById("stepHit" + j);
-				stepHit.style.left = (g_workObj.stepX[j] - 15) + "px";
+				//stepHit.style.left = (g_workObj.stepX[j] - 15) + "px";
 				stepHit.style.display = "inherit";
+				var frzHit = document.getElementById("frzHit" + j);
+				frzHit.style.left = g_workObj.stepX[j] + "px";
 
 			} else if (g_keyObj["color" + keyCtrlPtn][j] <= 1) {
 				displayOutStep(j);
@@ -159,10 +169,12 @@ function customMainInit2() {
 				g_workObj.dividePos[j] = (g_workObj.dividePos[j] == 0 ? 1 : 0);
 				g_workObj.scrollDir[j] = (g_workObj.scrollDir[j] == 1 ? -1 : 1);
 
-				var step = document.getElementById("step" + j);
+				var step = document.getElementById("stepRoot" + j);
 				step.style.top = (g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j]) + "px";
-				var stepHit = document.getElementById("stepHit" + j);
-				stepHit.style.top = (g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j] - 15) + "px";
+				//var stepHit = document.getElementById("stepHit" + j);
+				//stepHit.style.top = (g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j] - 15) + "px";
+				var frzHit = document.getElementById("frzHit" + j);
+				frzHit.style.top = (g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j]) + "px";
 			}
 		}
 	}
@@ -184,22 +196,22 @@ function customMainEnterFrame2() {
 
 			// 上段・右側4keyの矢印を回転しながら移動させる (11 → 11L)
 			g_tmpCnt1++;
-			var step4 = document.getElementById("step4");
+			var step4 = document.getElementById("stepRoot4");
 			step4.style.left = (parseFloat(step4.style.left) + 2.75) + "px";
 			var step4Rotate = g_keyObj["stepRtn" + keyCtrlPtn][4] + 9 * g_tmpCnt1;
 			step4.style.transform = "rotate(" + step4Rotate + "deg)";
 
-			var step5 = document.getElementById("step5");
+			var step5 = document.getElementById("stepRoot5");
 			step5.style.left = (parseFloat(step5.style.left) - 2.75) + "px";
 			var step5Rotate = g_keyObj["stepRtn" + keyCtrlPtn][5] + 9 * g_tmpCnt1;
 			step5.style.transform = "rotate(" + step5Rotate + "deg)";
 
-			var step6 = document.getElementById("step6");
+			var step6 = document.getElementById("stepRoot6");
 			step6.style.left = (parseFloat(step6.style.left) - 2.75 * 3) + "px";
 			var step6Rotate = g_keyObj["stepRtn" + keyCtrlPtn][6] + 9 * g_tmpCnt1;
 			step6.style.transform = "rotate(" + step6Rotate + "deg)";
 
-			var step7 = document.getElementById("step7");
+			var step7 = document.getElementById("stepRoot7");
 			step7.style.left = (parseFloat(step7.style.left) - 2.75 * 5) + "px";
 			var step7Rotate = g_keyObj["stepRtn" + keyCtrlPtn][7] + 9 * g_tmpCnt1;
 			step7.style.transform = "rotate(" + step7Rotate + "deg)";
@@ -210,7 +222,7 @@ function customMainEnterFrame2() {
 			// (移動完了の瞬間に、上段・右側4keyを非表示、上段・左側4keyを表示することで接続)
 			for (var j = 0; j < keyNum; j++) {
 				if (g_keyObj["color" + keyCtrlPtn][j] == 3) {
-					var step = document.getElementById("step" + j);
+					var step = document.getElementById("stepRoot" + j);
 					if (g_stateObj.d_stepzone != C_FLG_OFF) {
 						step.style.display = "inherit";
 					}
@@ -219,12 +231,15 @@ function customMainEnterFrame2() {
 					stepHit.style.display = "inherit";
 				}
 				if (g_keyObj["color" + keyCtrlPtn][j] == 4) {
-					var step = document.getElementById("step" + j);
+					var step = document.getElementById("stepRoot" + j);
 					step.style.left = g_workObj.stepX[j] + "px";
 					step.style.display = "none";
 
 					var stepHit = document.getElementById("stepHit" + j);
 					stepHit.style.display = "none";
+
+					var frzHit = document.getElementById("frzHit" + j);
+					frzHit.style.left = g_workObj.stepX[j] + "px";
 				}
 			}
 
@@ -235,56 +250,70 @@ function customMainEnterFrame2() {
 			// 
 			// 実際にはこの時点で上段・左側4keyの右半分は非表示になっており、
 			// 上段・右側4keyの右半分を左側4keyに寄せている
-			var step2 = document.getElementById("step2");
+			var step2 = document.getElementById("stepRoot2");
 			step2.style.display = "none";
-			var step3 = document.getElementById("step3");
+			var step3 = document.getElementById("stepRoot3");
 			step3.style.display = "none";
 			var stepHit2 = document.getElementById("stepHit2");
 			stepHit2.style.display = "none";
 			var stepHit3 = document.getElementById("stepHit3");
 			stepHit3.style.display = "none";
 
-			var step6 = document.getElementById("step6");
+			var step6 = document.getElementById("stepRoot6");
 			step6.style.left = step2.style.left;
 			if (g_stateObj.d_stepzone != C_FLG_OFF) {
 				step6.style.display = "inherit";
 			}
-			var step7 = document.getElementById("step7");
+			var step7 = document.getElementById("stepRoot7");
 			step7.style.left = step3.style.left;
 			if (g_stateObj.d_stepzone != C_FLG_OFF) {
 				step7.style.display = "inherit";
 			}
+
+			var frzHit6 = document.getElementById("frzHit6");
+			frzHit6.style.left = step2.style.left;
+			var frzHit7 = document.getElementById("frzHit7");
+			frzHit7.style.left = step3.style.left;
 
 		} else if (actualFrame <= 12899) {
 
 			// 上段・右側4keyの右半分の矢印を回転しながら移動させる (11L → 11F)
 			// 見た目は左側4keyだが、上述の通りすでに右側4keyの右半分にすり替わっている。
 			g_tmpCnt2++;
-			var step6 = document.getElementById("step6");
+			var step6 = document.getElementById("stepRoot6");
 			step6.style.left = (parseFloat(step6.style.left) + 2.75 * 2) + "px";
-			var step6Rotate = g_keyObj["stepRtn" + keyCtrlPtn][6] + 18 * g_tmpCnt2;
+			var step6Rotate = 18 * g_tmpCnt2;
 			step6.style.transform = "rotate(" + step6Rotate + "deg)";
 
-			var step7 = document.getElementById("step7");
+			var step7 = document.getElementById("stepRoot7");
 			step7.style.left = (parseFloat(step7.style.left) + 2.75 * 2) + "px";
-			var step7Rotate = g_keyObj["stepRtn" + keyCtrlPtn][7] + 18 * g_tmpCnt2;
+			var step7Rotate = 18 * g_tmpCnt2;
 			step7.style.transform = "rotate(" + step7Rotate + "deg)";
 
 		} else if (actualFrame == 12900) {
 
 			// 11F への移動確定
-			var step6 = document.getElementById("step6");
+			var step6 = document.getElementById("stepRoot6");
 			step6.style.left = g_workObj.stepX[6] + "px";
-			step6.style.transform = "rotate(" + g_keyObj["stepRtn" + keyCtrlPtn][6] + "deg)";
-			var step7 = document.getElementById("step7");
+			step6.style.transform = "rotate(0deg)";
+			var step7 = document.getElementById("stepRoot7");
 			step7.style.left = g_workObj.stepX[7] + "px";
-			step7.style.transform = "rotate(" + g_keyObj["stepRtn" + keyCtrlPtn][7] + "deg)";
+			step7.style.transform = "rotate(0deg)";
 
 			var stepHit6 = document.getElementById("stepHit6");
 			stepHit6.style.display = "inherit";
 			var stepHit7 = document.getElementById("stepHit7");
 			stepHit7.style.display = "inherit";
 
+			var frzHit6 = document.getElementById("frzHit6");
+			var frzHitTop6 = document.getElementById("frzHitTop6");
+			frzHit6.style.left = g_workObj.stepX[6] + "px";
+			frzHitTop6.style.transform = "rotate(" + g_keyObj["stepRtn" + keyCtrlPtn][6] + "deg)";
+
+			var frzHit7 = document.getElementById("frzHit7");
+			var frzHitTop7 = document.getElementById("frzHitTop7");
+			frzHit7.style.left = g_workObj.stepX[7] + "px";
+			frzHitTop7.style.transform = "rotate(" + g_keyObj["stepRtn" + keyCtrlPtn][7] + "deg)";
 		}
 	} else if (actualFrame <= 13845) {
 		if (actualFrame < 13753) {
@@ -298,10 +327,15 @@ function customMainEnterFrame2() {
 					stepHit.style.display = "none";
 				}
 			}
-			var step4 = document.getElementById("step4");
-			step4.style.transform = "rotate(" + g_keyObj["stepRtn" + keyCtrlPtn][4] + "deg)";
-			var step5 = document.getElementById("step5");
-			step5.style.transform = "rotate(" + g_keyObj["stepRtn" + keyCtrlPtn][5] + "deg)";
+			var step4 = document.getElementById("stepRoot4");
+			step4.style.transform = "rotate(0deg)";
+			var step5 = document.getElementById("stepRoot5");
+			step5.style.transform = "rotate(0deg)";
+
+			var frzHitTop4 = document.getElementById("frzHitTop4");
+			frzHitTop4.style.transform = "rotate(" + g_keyObj["stepRtn" + keyCtrlPtn][4] + "deg)";
+			var frzHitTop5 = document.getElementById("frzHitTop5");
+			frzHitTop5.style.transform = "rotate(" + g_keyObj["stepRtn" + keyCtrlPtn][5] + "deg)";
 
 		} else if (actualFrame < 13767) {
 			fadeOutStep(8);
@@ -342,24 +376,33 @@ function customMainEnterFrame2() {
 			fadeOutStep(11);
 
 			// 上段の見えている矢印を左右に移動させる
-			var step0 = document.getElementById("step0");
+			var step0 = document.getElementById("stepRoot0");
 			step0.style.left = (parseFloat(step0.style.left) - 3) + "px";
-			var step1 = document.getElementById("step1");
+			var step1 = document.getElementById("stepRoot1");
 			step1.style.left = (parseFloat(step1.style.left) - 3) + "px";
-			var step6 = document.getElementById("step6");
+			var step6 = document.getElementById("stepRoot6");
 			step6.style.left = (parseFloat(step6.style.left) + 3) + "px";
-			var step7 = document.getElementById("step7");
+			var step7 = document.getElementById("stepRoot7");
 			step7.style.left = (parseFloat(step7.style.left) + 3) + "px";
+
+			var frzHit0 = document.getElementById("frzHit0");
+			frzHit0.style.left = step0.style.left;
+			var frzHit1 = document.getElementById("frzHit1");
+			frzHit1.style.left = step1.style.left;
+			var frzHit6 = document.getElementById("frzHit6");
+			frzHit6.style.left = step6.style.left;
+			var frzHit7 = document.getElementById("frzHit7");
+			frzHit7.style.left = step7.style.left;
 
 		} else if (actualFrame < 13845) {
 			fadeOutStep(11);
-			var step0 = document.getElementById("step0");
+			var step0 = document.getElementById("stepRoot0");
 			step0.style.left = (parseFloat(step0.style.left) - 3) + "px";
-			var step1 = document.getElementById("step1");
+			var step1 = document.getElementById("stepRoot1");
 			step1.style.left = (parseFloat(step1.style.left) - 3) + "px";
-			var step6 = document.getElementById("step6");
+			var step6 = document.getElementById("stepRoot6");
 			step6.style.left = (parseFloat(step6.style.left) + 3) + "px";
-			var step7 = document.getElementById("step7");
+			var step7 = document.getElementById("stepRoot7");
 			step7.style.left = (parseFloat(step7.style.left) + 3) + "px";
 
 		} else if (actualFrame == 13845) {
@@ -373,11 +416,13 @@ function customMainEnterFrame2() {
 				if (g_keyObj["color" + keyCtrlPtn][j] == 3) {
 					g_workObj.stepX[j] -= 27.5 * 3;
 
-					var step = document.getElementById("step" + j);
+					var step = document.getElementById("stepRoot" + j);
 					step.style.left = g_workObj.stepX[j] + "px";
 					var stepHit = document.getElementById("stepHit" + j);
-					stepHit.style.left = (g_workObj.stepX[j] - 15) + "px";
+					//stepHit.style.left = (g_workObj.stepX[j] - 15) + "px";
 					stepHit.style.display = "inherit";
+					var frzHit = document.getElementById("frzHit" + j);
+					frzHit.style.left = g_workObj.stepX[j] + "px";
 
 					for (var k = g_workObj.judgArrowCnt[j]; ; k++) {
 						if (document.getElementById("arrow" + j + "_" + k) != null) {
@@ -392,11 +437,13 @@ function customMainEnterFrame2() {
 				} else if (g_keyObj["color" + keyCtrlPtn][j] == 4) {
 					g_workObj.stepX[j] += 27.5 * 3;
 
-					var step = document.getElementById("step" + j);
+					var step = document.getElementById("stepRoot" + j);
 					step.style.left = g_workObj.stepX[j] + "px";
 					var stepHit = document.getElementById("stepHit" + j);
-					stepHit.style.left = (g_workObj.stepX[j] - 15) + "px";
+					//stepHit.style.left = (g_workObj.stepX[j] - 15) + "px";
 					stepHit.style.display = "inherit";
+					var frzHit = document.getElementById("frzHit" + j);
+					frzHit.style.left = g_workObj.stepX[j] + "px";
 
 					for (var k = g_workObj.judgArrowCnt[j]; ; k++) {
 						if (document.getElementById("arrow" + j + "_" + k) != null) {
@@ -413,10 +460,12 @@ function customMainEnterFrame2() {
 					g_workObj.dividePos[j] = (g_workObj.dividePos[j] == 0 ? 1 : 0);
 					g_workObj.scrollDir[j] = (g_workObj.scrollDir[j] == 1 ? -1 : 1);
 
-					var step = document.getElementById("step" + j);
+					var step = document.getElementById("stepRoot" + j);
 					step.style.top = (g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j]) + "px";
-					var stepHit = document.getElementById("stepHit" + j);
-					stepHit.style.top = (g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j] - 15) + "px";
+					//var stepHit = document.getElementById("stepHit" + j);
+					//stepHit.style.top = (g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j] - 15) + "px";
+					var frzHit = document.getElementById("frzHit" + j);
+					frzHit.style.top = (g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j]) + "px";
 				}
 			}
 			displayInStep(2);

--- a/js/danoni_custom-0216.js
+++ b/js/danoni_custom-0216.js
@@ -17,15 +17,15 @@
  * 　画面遷移したときにきれいに消してくれます。
  */
 
-let g_tmpCnt1 = 0;
-let g_tmpCnt2 = 0;
+var g_tmpCnt1 = 0;
+var g_tmpCnt2 = 0;
 
 /**
  * タイトル画面 [Scene: Title / Melon]
  */
 function customTitleInit2() {
 	// バージョン表記
-	g_localVersion2 = `sp-1`;
+	g_localVersion2 = `sp-4`;
 	document.body.style.backgroundColor = "#110011";
 }
 
@@ -82,21 +82,27 @@ function customMainInit2() {
 
 		if (g_keyObj[`color${keyCtrlPtn}`][j] === 3) {
 
-			const step = document.querySelector(`#step${j}`);
+			const step = document.querySelector(`#stepRoot${j}`);
 			g_workObj.stepX[j] += 55;
 			step.style.left = `${g_workObj.stepX[j]}px`;
 
-			const stepHit = document.querySelector(`#stepHit${j}`);
-			stepHit.style.left = `${parseFloat(g_workObj.stepX[j] - 15)}px`;
+			//const stepHit = document.querySelector(`#stepHit${j}`);
+			//stepHit.style.left = `${parseFloat(g_workObj.stepX[j] - 15)}px`;
+
+			const frzHit = document.querySelector(`#frzHit${j}`);
+			frzHit.style.left = `${g_workObj.stepX[j]}px`;
 
 		} else if (g_keyObj[`color${keyCtrlPtn}`][j] === 4) {
 
-			const step = document.querySelector(`#step${j}`);
+			const step = document.querySelector(`#stepRoot${j}`);
 			g_workObj.stepX[j] -= 55;
 			step.style.left = `${g_workObj.stepX[j]}px`;
 
-			const stepHit = document.querySelector(`#stepHit${j}`);
-			stepHit.style.left = `${parseFloat(g_workObj.stepX[j] - 15)}px`;
+			//const stepHit = document.querySelector(`#stepHit${j}`);
+			//stepHit.style.left = `${parseFloat(g_workObj.stepX[j] - 15)}px`;
+
+			const frzHit = document.querySelector(`#frzHit${j}`);
+			frzHit.style.left = `${g_workObj.stepX[j]}px`;
 		}
 	}
 
@@ -104,8 +110,10 @@ function customMainInit2() {
 		// 7key
 		for (var j = 0; j < keyNum; j++) {
 
+			const stepRoot = document.querySelector(`#stepRoot${j}`);
 			const step = document.querySelector(`#step${j}`);
 			const stepHit = document.querySelector(`#stepHit${j}`);
+			const frzHit = document.querySelector(`#frzHit${j}`);
 
 			if (g_keyObj[`color${keyCtrlPtn}`][j] >= 3) {
 				// 11key, 11Lkeyの上段を隠す
@@ -117,8 +125,9 @@ function customMainInit2() {
 				g_workObj.dividePos[j] = (g_workObj.dividePos[j] === 0 ? 1 : 0);
 				g_workObj.scrollDir[j] = (g_workObj.scrollDir[j] === 1 ? -1 : 1);
 
-				step.style.top = `${(g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j])}px`;
-				stepHit.style.top = `${(g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j] - 15)}px`;
+				stepRoot.style.top = `${(g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j])}px`;
+				//stepHit.style.top = `${(g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j] - 15)}px`;
+				frzHit.style.top = `${(g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j])}px`;
 			}
 		}
 
@@ -126,7 +135,7 @@ function customMainInit2() {
 		// 11Lkey
 		for (var j = 0; j < keyNum; j++) {
 
-			const step = document.querySelector(`#step${j}`);
+			const step = document.querySelector(`#stepRoot${j}`);
 			const stepHit = document.querySelector(`#stepHit${j}`);
 
 			if (g_keyObj[`color${keyCtrlPtn}`][j] === 4) {
@@ -143,7 +152,7 @@ function customMainInit2() {
 		// 11Lkey
 		for (var j = 0; j < keyNum; j++) {
 
-			const step = document.querySelector(`#step${j}`);
+			const step = document.querySelector(`#stepRoot${j}`);
 			const stepHit = document.querySelector(`#stepHit${j}`);
 
 			if (g_keyObj[`color${keyCtrlPtn}`][j] === 4) {
@@ -157,7 +166,7 @@ function customMainInit2() {
 		// 11key
 		for (var j = 0; j < keyNum; j++) {
 
-			const step = document.querySelector(`#step${j}`);
+			const step = document.querySelector(`#stepRoot${j}`);
 			const stepHit = document.querySelector(`#stepHit${j}`);
 
 			if (g_keyObj[`color${keyCtrlPtn}`][j] === 3) {
@@ -170,7 +179,7 @@ function customMainInit2() {
 		// 11Lkey
 		for (var j = 0; j < keyNum; j++) {
 
-			const step = document.querySelector(`#step${j}`);
+			const step = document.querySelector(`#stepRoot${j}`);
 			const stepHit = document.querySelector(`#stepHit${j}`);
 
 			if (g_keyObj[`color${keyCtrlPtn}`][j] === 4) {
@@ -214,10 +223,12 @@ function customMainEnterFrame2() {
 
 			// 7key部の半分を下段へ移動
 			for (let j = 8; j <= 11; j++) {
-				const step = document.querySelector(`#step${j}`);
-				const stepHit = document.querySelector(`#stepHit${j}`);
+				const step = document.querySelector(`#stepRoot${j}`);
+				//const stepHit = document.querySelector(`#stepHit${j}`);
+				const frzHit = document.querySelector(`#frzHit${j}`);
 				step.style.top = `${(g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j])}px`;
-				stepHit.style.top = `${(g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j] - 15)}px`;
+				//stepHit.style.top = `${(g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j] - 15)}px`;
+				frzHit.style.top = `${(g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j])}px`;
 			}
 
 			// 7key部の残りの矢印のスクロール方向を反転
@@ -231,10 +242,10 @@ function customMainEnterFrame2() {
 
 			// 7key部の残りを下段へ移動
 			for (let j = 12; j <= 14; j++) {
-				const step = document.querySelector(`#step${j}`);
-				const stepHit = document.querySelector(`#stepHit${j}`);
+				const step = document.querySelector(`#stepRoot${j}`);
+				//const stepHit = document.querySelector(`#stepHit${j}`);
 				step.style.top = `${(g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j])}px`;
-				stepHit.style.top = `${(g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j] - 15)}px`;
+				//stepHit.style.top = `${(g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j] - 15)}px`;
 			}
 
 			// 11Lkey上段をうっすら表示
@@ -248,6 +259,11 @@ function customMainEnterFrame2() {
 						stepHit.style.display = `inherit`;
 					}
 				}
+			}
+		} else if (actualFrame === 3000) {
+			for (let j = 12; j <= 14; j++) {
+				const frzHit = document.querySelector(`#frzHit${j}`);
+				frzHit.style.top = `${(g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j])}px`;
 			}
 		} else if (actualFrame < 4356) {
 		} else if (actualFrame === 4356) {
@@ -270,7 +286,7 @@ function customMainEnterFrame2() {
 		g_tmpCnt1++;
 		for (var j = 0; j < keyNum; j++) {
 			if (g_keyObj[`color${keyCtrlPtn}`][j] === 3) {
-				const step = document.querySelector(`#step${j}`);
+				const step = document.querySelector(`#stepRoot${j}`);
 				step.style.left = `${parseFloat(step.style.left) + 0.1375 * (41 - g_tmpCnt1)}px`;
 			}
 		}
@@ -281,8 +297,10 @@ function customMainEnterFrame2() {
 
 		// 11key上段を表示、11Lkey上段は非表示にして元の位置に戻す
 		for (var j = 0; j < keyNum; j++) {
+			const stepRoot = document.querySelector(`#stepRoot${j}`);
 			const step = document.querySelector(`#step${j}`);
 			const stepHit = document.querySelector(`#stepHit${j}`);
+			const frzHit = document.querySelector(`#frzHit${j}`);
 
 			if (g_keyObj[`color${keyCtrlPtn}`][j] === 4) {
 				if (g_stateObj.d_stepzone != C_FLG_OFF) {
@@ -291,8 +309,10 @@ function customMainEnterFrame2() {
 				}
 
 			} else if (g_keyObj[`color${keyCtrlPtn}`][j] === 3) {
-				step.style.left = `${g_workObj.stepX[j]}px`;
-				stepHit.style.left = `${parseFloat(g_workObj.stepX[j] - 15)}px`;
+				stepRoot.style.left = `${g_workObj.stepX[j]}px`;
+				//step.style.left = `${g_workObj.stepX[j]}px`;
+				//stepHit.style.left = `${parseFloat(g_workObj.stepX[j] - 15)}px`;
+				frzHit.style.left = `${g_workObj.stepX[j]}px`;
 
 				step.style.display = `none`;
 				stepHit.style.display = `none`;

--- a/js/danoni_custom-0316.js
+++ b/js/danoni_custom-0316.js
@@ -25,7 +25,7 @@
  */
 function customTitleInit2() {
     // バージョン表記
-    g_localVersion2 = "sp-1";
+    g_localVersion2 = "sp-3";
     document.body.style.backgroundColor = "#111100";
 }
 
@@ -67,9 +67,9 @@ function customMainInit2() {
     var keyCtrlPtn = g_keyObj.currentKey + "_" + g_keyObj.currentPtn;
     var keyNum = g_keyObj["chara" + keyCtrlPtn].length;
 
-    var frameNum = g_scoreObj.frameNum;
-    var preblankFrame = g_headerObj.blankFrame - g_headerObj.blankFrameDef + g_stateObj.adjustment;
-    var actualFrame = frameNum - preblankFrame;
+    //var frameNum = g_scoreObj.frameNum;
+    //var preblankFrame = g_headerObj.blankFrame - g_headerObj.blankFrameDef + g_stateObj.adjustment;
+    var actualFrame = g_scoreObj.baseFrame;
 
     document.body.style.backgroundColor = "#111100";
 
@@ -101,9 +101,10 @@ function customMainInit2() {
  * メイン画面(フレーム毎表示) [Scene: Main / Banana]
  */
 function customMainEnterFrame2() {
-    var frameNum = g_scoreObj.frameNum;
-    var preblankFrame = g_headerObj.blankFrame - g_headerObj.blankFrameDef + g_stateObj.adjustment;
-    var actualFrame = frameNum - preblankFrame;
+    //var frameNum = g_scoreObj.frameNum;
+    //var preblankFrame = g_headerObj.blankFrame - g_headerObj.blankFrameDef + g_stateObj.adjustment;
+    //var actualFrame = frameNum - preblankFrame;
+    var actualFrame = g_scoreObj.baseFrame;
     var keyCtrlPtn = g_keyObj.currentKey + "_" + g_keyObj.currentPtn;
     var keyNum = g_keyObj["chara" + keyCtrlPtn].length;
 
@@ -205,7 +206,7 @@ function fadeInStep(_pos) {
 function displayInStep(_pos) {
     var step = document.getElementById("step" + _pos);
     step.style.opacity = 0;
-    if (g_stateObj.d_stepzone != C_FLG_OFF) {
+    if (g_stateObj.d_stepzone != C_FLG_OFF && g_stateObj.scroll !== `Flat`) {
         step.style.display = "inherit";
     }
 }

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -6,13 +6,16 @@
  * 譜面データ側で個別に同様の項目が設定されている場合は、譜面データ側の設定が優先されます。
  * 例えばこのファイルで g_presetTuning = `onigiri` とすると全ての作品に製作者名として「onigiri」が設定されますが、
  * 譜面データ側で |tuning=washoi| とするとその作品には製作者名として「washoi」が設定されます。
+ * 
+ * Revised: 2019/11/20
+ * Local Version: 0.3.0
  */
 
 // 譜面製作者名
 const g_presetTuning = `ティックル`;
 
 // 譜面製作者URL
-const g_presetTuningUrl = `http://cw7.sakura.ne.jp/`;
+const g_presetTuningUrl = `https://cw7.sakura.ne.jp/`;
 
 // ゲージ設定（デフォルト）
 const g_presetGauge = {
@@ -36,6 +39,24 @@ const g_presetGaugeCustom = {
 		Damage: 50,
 		Init: 100,
 	},
+	NoRecovery: {
+		Border: `x`,
+		Recovery: 0,
+		Damage: 50,
+		Init: 100,
+	},
+	SuddenDeath: {
+		Border: `x`,
+		Recovery: 0,
+		Damage: setVal(g_rootObj.maxLifeVal, C_VAL_MAXLIFE, C_TYP_FLOAT),
+		Init: 100,
+	},
+	Practice: {
+		Border: `x`,
+		Recovery: 0,
+		Damage: 0,
+		Init: 50,
+	}
 };
 
 // デフォルトのデザインを使用せず、独自のデザインを使用するかを指定
@@ -52,9 +73,11 @@ const g_presetCustomDesignUse = {
 // 一律使用させたくない場合は `false` を指定（デフォルトは `true`）
 const g_presetSettingUse = {
 	motion: `true`,
+	scroll: `true`,
 	shuffle: `true`,
 	autoPlay: `true`,
-	gauge: `true`
+	gauge: `true`,
+	appearance: `true`,
 };
 
 g_presetFrzStartjdgUse = `false`;
@@ -62,6 +85,8 @@ g_presetFrzStartjdgUse = `false`;
 // 7key用のキーコン設定
 // 1: Cross, 2: Split, 3: Alternate, 4:Twist, 5:Asymmetry
 // transKeyを定義しているため、演出によりこれらを使わせたくない作品には |transKeyUse=false| を使用する。
+/*
+v10.2.0のスクロール拡張により不要になったため削除
 g_keyObj.chara7_1 = [`left`, `leftdia`, `rightdia`, `right`, `down`, `space`, `up`];
 g_keyObj.chara7_2 = [`left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`];
 g_keyObj.chara7_3 = [`left`, `down`, `up`, `right`, `leftdia`, `space`, `rightdia`];
@@ -115,6 +140,7 @@ g_keyObj.transKey7_2 = `Split`;
 g_keyObj.transKey7_3 = `Alternate`;
 g_keyObj.transKey7_4 = `Twist`;
 g_keyObj.transKey7_5 = `Asymmetry`;
+*/
 
 // 作品個別に定義する場合は下記と同じ
 /*


### PR DESCRIPTION
## 変更内容
- ver10.2.1で対応した、スクロール拡張（主にFlat）及び
ステップゾーン位置の仕様変更に対応しました。

### danoni_setting.js
- 本体のスクロール拡張実装により不要となった設定の削除
- サイトURL変更
- バージョン表記を追加

### No.166
- customデータの複数回読込に伴い、let定義のグローバル変数をvarに置き換え
- ステップゾーン空押し部分(stepDivX)の表示／非表示に対応
- Flat使用時にステップゾーンが表示されないよう変更

### No.190
- 基本的にステップゾーン全体(stepRootX)を使用した書き方に変更
- フリーズアローヒット部分の独立に伴い、フリーズアローヒット部分の座標計算を追加

### No.216
- customデータの複数回読込に伴い、let定義のグローバル変数をvarに置き換え
- フリーズアローヒット部分の独立に伴い、フリーズアローヒット部分の座標計算を追加
- 基本的にステップゾーン全体(stepRootX)を使用した書き方に変更
（ただし透明度の変更は従来通り、各個別のオブジェクトで対応）

### No.316
- baseFrameを使用した書き方に変更（他の作品も随時対応予定）
- Flat使用時にステップゾーンが表示されないよう変更

## 変更理由
- そのままの状態では動作に影響するため。