### PR TITLE
[ti-7.4] 特殊文字対応に伴い、曲名・アーティスト名をHTML対応させるよう変更

### DIFF
--- a/js/danoni_custom.js
+++ b/js/danoni_custom.js
@@ -47,7 +47,7 @@ function customLoadingProgress(_event) {
 function customTitleInit() {
 
 	// バージョン表記
-	g_localVersion = `ti-7.3`;
+	g_localVersion = `ti-7.4`;
 
 	// 製作者のデフォルトアドレス
 	if (g_headerObj.creatorUrl === location.href) {
@@ -56,10 +56,10 @@ function customTitleInit() {
 
 	// 楽曲タイトル、アーティスト名の自動反映（Thanks: MFV2さん)
 	if (document.getElementById(`musicTitle`) !== null) {
-		document.getElementById(`musicTitle`).innerText = g_headerObj.musicTitle;
+		document.getElementById(`musicTitle`).innerHTML = g_headerObj.musicTitle;
 	}
 	if (document.getElementById(`artistName`) !== null) {
-		document.getElementById(`artistName`).innerText = g_headerObj.artistName;
+		document.getElementById(`artistName`).innerHTML = g_headerObj.artistName;
 		document.getElementById(`artistName`).href = g_headerObj.artistUrl;
 	}
 


### PR DESCRIPTION
## 変更内容
- 特殊文字対応に伴い、曲名・アーティスト名表示をHTML対応させるよう変更しました。

### 変更前
```javascript
document.getElementById(`musicTitle`).innerText = g_headerObj.musicTitle;
```
### 変更後
```javascript
document.getElementById(`musicTitle`).innerHTML = g_headerObj.musicTitle;
```

## 変更理由
- 特殊文字の置き換えはinnerTextではなくinnerHTMLでないと解釈されないため。

## その他
- JavaScriptの記述形式が本体と合っていないため、
後ほど整理して対応する予定。