### PR TITLE
[ti-8.8] g_customJsObjを使って全体的に見直し

### DIFF
--- a/js/danoni_custom.js
+++ b/js/danoni_custom.js
@@ -4,13 +4,150 @@
  * [for Cross Walker]
  * 
  * 作品共通カスタム設定
- * 　・カスタム変数の定義 (titlesize, titlefont)
  * 　・製作者のデフォルトアドレス指定
  * 　・楽曲タイトル、アーティスト名の自動反映
- * 　・Readyモーション
- * 　・背景設定
  * 　・独自スコア計算式(Type2: izkdicさん方式, Type3: FUJIさん方式)
  */
+
+g_customJsObj.preTitle.push(() => {
+
+	// 各種ページタイトルのアニメーション設定
+	const animationTitles = [`option`, `settingsDisplay`, `exSetting`, `keyconfig`, `result`];
+	animationTitles.forEach(window => g_customJsObj[window].push(() => {
+		const lblTitle = document.getElementById(`lblTitle`);
+		lblTitle.style.animationDuration = `1.5s`;
+		lblTitle.style.animationName = `upToDown`;
+	}));
+
+	// スコア機構の独自処理一式
+	if (g_rootObj.scoreType === `Type2` || g_rootObj.scoreType === `Type3`) {
+	
+		g_customJsObj.title.push(() => {
+			// 初項
+			g_headerObj.calcFirstTerm = 0;
+			// 公差
+			g_headerObj.calcDifference = 0;
+			// フリーズ基本点
+			g_headerObj.calcFreeze = 0;
+			// 得点率 (誤差フレーム数毎に定義)
+			g_headerObj.calcScoreRates = [100, 99, 95, 80, 60, 30];
+
+			// スコア除数（Type3用）
+			g_headerObj.cutRate = 0;
+			// 基準コンボ数（Type3用）
+			g_headerObj.cutCombo = 0;
+
+			if (g_rootObj.scoreType === `Type3`) {
+				// 判定強制変更（暫定）
+				g_judgObj.arrowJ = [1, 3, 5, 7, 7];
+				g_judgObj.frzJ = [1, 5, 7];
+				g_headerObj.judgRangeUse = false;
+			}
+		});
+		g_customJsObj.option.push(() => {
+			multiAppend(difficultySprite,
+				createDivCss2Label(`lblScType`, `Score: ${g_rootObj.scoreType}`, {
+					x: 13, y: 17, w: g_sWidth, h: g_limitObj.setLblHeight,
+					siz: 12, align: C_ALIGN_LEFT,
+				})
+			);
+		});
+		
+		g_customJsObj.loading.push(() => {
+			// 実際のスコア
+			g_resultObj.realScore = 0;
+			// ドラムロール上のスコア
+			g_workObj.viewScore = 0;
+			// 実際のスコア - ドラムロール上のスコア
+			g_workObj.tempScore = 0;
+			// 桜点（Type3用）
+			g_workObj.sakuraScore = 0;
+
+			// スコア機構
+			if (g_rootObj.scoreType === `Type2`) {
+
+				let scoreIdHeader = ``;
+				if (g_stateObj.scoreId > 0) {
+					scoreIdHeader = Number(g_stateObj.scoreId) + 1;
+				}
+
+				// 譜面データより初項、公差、フリーズ基本点を取得
+				if (g_rootObj.calc_data !== undefined && g_rootObj.calc_data !== ``) {
+					const calcs = g_rootObj[`calc` + scoreIdHeader + `_data`].split(`,`);
+					g_headerObj.calcFirstTerm = parseInt(calcs[0]);
+					g_headerObj.calcDifference = parseInt(calcs[1]);
+					g_headerObj.calcFreeze = parseInt(calcs[2]);
+				}
+
+			} else if (g_rootObj.scoreType === `Type3`) {
+				// 基準コンボ数は総ノート数÷10（小数以下切り捨て）
+				// 計算結果が1未満になった場合は1とする
+				g_headerObj.cutCombo = (g_fullArrows > 10) ? Math.floor(g_fullArrows / 10) : 1;
+
+				// スコア除数は総ノート数÷100
+				// 計算結果が1未満になった場合は1とする
+				g_headerObj.cutRate = (g_fullArrows > 100) ? g_fullArrows / 100 : 1.00;
+
+			}
+		});
+	
+		g_customJsObj.main.push(() => {
+			const judgeSprite = document.getElementById(`judgeSprite`);
+
+			multiAppend(judgeSprite,
+				createDivCss2Label(`lblScore`, `Score:`, {
+					x: g_sWidth * 3 / 4, y: g_headerObj.playingY + g_headerObj.playingHeight - 30, w: g_sWidth / 4 - 50, h: 30,
+					siz: 14, color: `#ffffff`, align: C_ALIGN_LEFT, fontFamily: C_LBL_BASICFONT,
+				}),
+				createDivCss2Label(`lblScoreRoll`, g_workObj.viewScore, {
+					x: g_sWidth / 2, y: g_headerObj.playingY + g_headerObj.playingHeight - 30, w: g_sWidth / 2 - 10, h: 30,
+					siz: 14, color: `#ffffff`, align: C_ALIGN_RIGHT, fontFamily: C_LBL_BASICFONT,
+				}),
+			);
+
+			if (g_stateObj.d_score === C_FLG_OFF) {
+				lblScore.style.visibility = `hidden`;
+				lblScoreRoll.style.visibility = `hidden`;
+			}
+		});
+		g_customJsObj.mainEnterFrame.push(() => {
+			// スコアドラムロール
+			if (g_resultObj.realScore > g_workObj.viewScore) {
+				g_workObj.tempScore = g_resultObj.realScore - g_workObj.viewScore;
+				if (g_workObj.tempScore < 100) {
+					g_workObj.viewScore += 1;
+				} else if (g_workObj.tempScore < 1000) {
+					g_workObj.viewScore += 11;
+				} else if (g_workObj.tempScore < 10000) {
+					g_workObj.viewScore += 111;
+				} else if (g_workObj.tempScore < 100000) {
+					g_workObj.viewScore += 1111;
+				} else {
+					g_workObj.viewScore += 11111;
+				}
+				document.getElementById(`lblScoreRoll`).innerHTML = g_workObj.viewScore;
+			}
+		});
+		g_customJsObj.judg_ii.push((difFrame) => calcArrowRcv[g_rootObj.scoreType](difFrame, 1, 5));
+		g_customJsObj.judg_shakin.push((difFrame) => calcArrowRcv[g_rootObj.scoreType](difFrame, 0.8, 4));
+		g_customJsObj.judg_matari.push((difFrame) => calcArrowRcv[g_rootObj.scoreType](difFrame));
+		g_customJsObj.judg_shobon.push((difFrame) => calcArrowDmg[g_rootObj.scoreType](50));
+		g_customJsObj.judg_uwan.push((difFrame) => calcArrowDmg[g_rootObj.scoreType](100));
+		g_customJsObj.judg_kita.push((difFrame) => {
+			if (g_rootObj.scoreType === `Type2`) {
+				g_resultObj.realScore += Math.floor(g_headerObj.calcFreeze);
+			} else if (g_rootObj.scoreType === `Type3`) {
+				calcArrowRcv.Type3(difFrame, 1, 5);
+			}
+		});
+		g_customJsObj.judg_iknai.push((difFrame) => calcArrowDmg[g_rootObj.scoreType](100));
+		
+		g_customJsObj.result.push(() => {
+			g_resultObj.score = g_resultObj.realScore;
+			document.getElementById(`lblScoreS`).innerHTML = g_resultObj.score;
+		});
+	}
+});
 
 /**
  * ローディング中処理
@@ -39,11 +176,11 @@ function customLoadingProgress(_event) {
 function customTitleInit() {
 
 	// バージョン表記
-	g_localVersion = `ti-8.2`;
+	g_localVersion = `ti-8.8`;
 
 	// 製作者のデフォルトアドレス
 	if (g_headerObj.creatorUrl === location.href) {
-		g_headerObj.creatorUrl = `http://cw7.sakura.ne.jp/`;
+		g_headerObj.creatorUrl = `https://cw7.sakura.ne.jp/`;
 	}
 
 	// 楽曲タイトル、アーティスト名の自動反映（Thanks: MFV2さん)
@@ -54,187 +191,9 @@ function customTitleInit() {
 		document.getElementById(`artistName`).innerHTML = g_headerObj.artistName;
 		document.getElementById(`artistName`).href = g_headerObj.artistUrl;
 	}
-
-	// 初項
-	g_headerObj.calcFirstTerm = 0;
-	// 公差
-	g_headerObj.calcDifference = 0;
-	// フリーズ基本点
-	g_headerObj.calcFreeze = 0;
-	// 得点率 (誤差フレーム数毎に定義)
-	g_headerObj.calcScoreRates = [100, 99, 95, 80, 60, 30];
-
-	// スコア除数（Type3用）
-	g_headerObj.cutRate = 0;
-	// 基準コンボ数（Type3用）
-	g_headerObj.cutCombo = 0;
-
+	
 	if (g_rootObj.scoreType === undefined) {
 		g_rootObj.scoreType = `Type1`;
-	}
-}
-
-/**
- * オプション画面(初期表示) [Scene: Option / Lime]
- */
-function customOptionInit() {
-
-	const lblTitle = document.getElementById(`lblTitle`);
-	lblTitle.style.animationDuration = `1.5s`;
-	lblTitle.style.animationName = `upToDown`;
-
-	if (g_rootObj.scoreType !== `Type1`) {
-		multiAppend(gaugeSprite,
-			createDivCss2Label(`lblScType`, `Score: ${g_rootObj.scoreType}`, {
-				x: 13, y: 22, w: g_sWidth, h: C_LEN_SETLBL_HEIGHT,
-				siz: 12, align: C_ALIGN_LEFT,
-			})
-		);
-	}
-}
-
-/**
- * 譜面選択(Difficultyボタン)時カスタム処理
- * @param {boolean} _initFlg 譜面変更フラグ (true:譜面変更選択時 / false:画面遷移による移動時)
- * @param {boolean} _canLoadDifInfoFlg 譜面初期化フラグ (true:譜面設定を再読込 / false:譜面設定を引き継ぐ)
- */
-function customSetDifficulty(_initFlg, _canLoadDifInfoFlg) {
-
-}
-
-/**
- * 表示変更(初期表示) [Scene: Settings-Display / Lemon]
- */
-function customSettingsDisplayInit() {
-
-	const lblTitle = document.getElementById(`lblTitle`);
-	lblTitle.style.animationDuration = `1.5s`;
-	lblTitle.style.animationName = `upToDown`;
-
-}
-
-/**
- * キーコンフィグ画面(初期表示) [Scene: KeyConfig / Orange]
- */
-function customKeyConfigInit() {
-
-	const lblTitle = document.getElementById(`lblTitle`);
-	lblTitle.style.animationDuration = `1.5s`;
-	lblTitle.style.animationName = `upToDown`;
-}
-
-/**
- * 譜面読込画面 [Scene: Loading / Strawberry]
- * - この画面のみ、画面表示がありません。
- * - 処理が完了すると、自動的にメイン画面へ遷移します。
- */
-function customLoadingInit() {
-
-	// 実際のスコア
-	g_resultObj.realScore = 0;
-	// ドラムロール上のスコア
-	g_workObj.viewScore = 0;
-	// 実際のスコア - ドラムロール上のスコア
-	g_workObj.tempScore = 0;
-	// 桜点（Type3用）
-	g_workObj.sakuraScore = 0;
-
-	// スコア機構
-	if (g_rootObj.scoreType === `Type2`) {
-
-		let scoreIdHeader = ``;
-		if (g_stateObj.scoreId > 0) {
-			scoreIdHeader = Number(g_stateObj.scoreId) + 1;
-		}
-
-		// 譜面データより初項、公差、フリーズ基本点を取得
-		if (g_rootObj.calc_data !== undefined && g_rootObj.calc_data !== ``) {
-			const calcs = g_rootObj[`calc` + scoreIdHeader + `_data`].split(`,`);
-			g_headerObj.calcFirstTerm = parseInt(calcs[0]);
-			g_headerObj.calcDifference = parseInt(calcs[1]);
-			g_headerObj.calcFreeze = parseInt(calcs[2]);
-		}
-
-	} else if (g_rootObj.scoreType === `Type3`) {
-		// 基準コンボ数は総ノート数÷10（小数以下切り捨て）
-		// 計算結果が1未満になった場合は1とする
-		g_headerObj.cutCombo = (g_fullArrows > 10) ? Math.floor(g_fullArrows / 10) : 1;
-
-		// スコア除数は総ノート数÷100
-		// 計算結果が1未満になった場合は1とする
-		g_headerObj.cutRate = (g_fullArrows > 100) ? g_fullArrows / 100 : 1.00;
-
-		// 判定強制変更（暫定）
-		g_judgObj.arrowJ = [1, 3, 5, 7, 7];
-		g_judgObj.frzJ = [1, 5, 7];
-	}
-}
-
-/**
- * メイン画面(初期表示) [Scene: Main / Banana]
- */
-function customMainInit() {
-
-	// スコアドラムロール
-	if (g_rootObj.scoreType === `Type2` || g_rootObj.scoreType === `Type3`) {
-		const judgeSprite = document.getElementById(`judgeSprite`);
-
-		multiAppend(judgeSprite,
-			createDivCss2Label(`lblScore`, `Score:`, {
-				x: g_sWidth * 3 / 4, y: g_sHeight - 30, w: g_sWidth / 4 - 50, h: 30,
-				siz: 14, color: `#ffffff`, align: C_ALIGN_LEFT, fontFamily: C_LBL_BASICFONT,
-			}),
-			createDivCss2Label(`lblScoreRoll`, g_workObj.viewScore, {
-				x: g_sWidth / 2, y: g_sHeight - 30, w: g_sWidth / 2 - 10, h: 30,
-				siz: 14, color: `#ffffff`, align: C_ALIGN_RIGHT, fontFamily: C_LBL_BASICFONT,
-			}),
-		);
-
-		if (g_stateObj.d_score === C_FLG_OFF) {
-			lblScore.style.visibility = `hidden`;
-			lblScoreRoll.style.visibility = `hidden`;
-		}
-	}
-}
-
-/**
- * メイン画面(フレーム毎表示) [Scene: Main / Banana]
- */
-function customMainEnterFrame() {
-
-	// スコアドラムロール
-	if (g_rootObj.scoreType === `Type2` || g_rootObj.scoreType === `Type3`) {
-		if (g_resultObj.realScore > g_workObj.viewScore) {
-			g_workObj.tempScore = g_resultObj.realScore - g_workObj.viewScore;
-			if (g_workObj.tempScore < 100) {
-				g_workObj.viewScore += 1;
-			} else if (g_workObj.tempScore < 1000) {
-				g_workObj.viewScore += 11;
-			} else if (g_workObj.tempScore < 10000) {
-				g_workObj.viewScore += 111;
-			} else if (g_workObj.tempScore < 100000) {
-				g_workObj.viewScore += 1111;
-			} else {
-				g_workObj.viewScore += 11111;
-			}
-			document.getElementById(`lblScoreRoll`).innerHTML = g_workObj.viewScore;
-		}
-	}
-}
-
-/**
- * 結果画面(初期表示) [Scene: Result / Grape]
- */
-function customResultInit() {
-
-	const lblTitle = document.getElementById(`lblTitle`);
-	lblTitle.style.animationDuration = `1.5s`;
-	lblTitle.style.animationName = `upToDown`;
-
-	// スコア計算
-	if (g_rootObj.scoreType === `Type2` || g_rootObj.scoreType === `Type3`) {
-		g_resultObj.score = g_resultObj.realScore;
-		document.getElementById(`lblScoreS`).innerHTML = g_resultObj.score;
 	}
 }
 
@@ -282,46 +241,3 @@ const calcArrowDmg = {
 		}
 	},
 };
-
-/**
- * 判定カスタム処理 (引数は共通で1つ保持)
- * @param {number} difFrame タイミング誤差(フレーム数)
- */
-// イイ
-function customJudgeIi(difFrame) {
-	calcArrowRcv[g_rootObj.scoreType](difFrame, 1, 5);
-}
-
-// シャキン
-function customJudgeShakin(difFrame) {
-	calcArrowRcv[g_rootObj.scoreType](difFrame, 0.8, 4);
-}
-
-// マターリ
-function customJudgeMatari(difFrame) {
-	calcArrowRcv[g_rootObj.scoreType](difFrame);
-}
-
-// ショボーン
-function customJudgeShobon(difFrame) {
-	calcArrowDmg[g_rootObj.scoreType](50);
-}
-
-// ウワァン
-function customJudgeUwan(difFrame) {
-	calcArrowDmg[g_rootObj.scoreType](100);
-}
-
-// キター
-function customJudgeKita(difFrame) {
-	if (g_rootObj.scoreType === `Type2`) {
-		g_resultObj.realScore += Math.floor(g_headerObj.calcFreeze);
-	} else if (g_rootObj.scoreType === `Type3`) {
-		calcArrowRcv.Type3(difFrame, 1, 5);
-	}
-}
-
-// イクナイ
-function customJudgeIknai(difFrame) {
-	calcArrowDmg[g_rootObj.scoreType](100);
-}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. 一部を除きg_customJsObjを使う方法に置き換え
- 基本的にg_customJsObjを使う方法に置き換えました。
- g_customJsObjを使う方法では条件分岐で関数の追加が可能なため、独自スコア機構を使わない作品では
関数の丸ごとスキップができるようになります。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. ほとんどが独自スコア機構を使わない構成になっているにもかかわらず、空の関数を通過させていたため。

## :pencil: その他コメント / Other Comments